### PR TITLE
docs: Fix spelling error in "preferred"

### DIFF
--- a/docs/tutorials/builders/02-configure-account.md
+++ b/docs/tutorials/builders/02-configure-account.md
@@ -29,7 +29,7 @@ In the "Profile" page, you should complete your name, email address and country 
 
 ## 3. Select your preferred payment method
 
-You can configure your prefered method receive payments: via Stripe integration for fiat and/or crypto. 
+You can configure your preferred method receive payments: via Stripe integration for fiat and/or crypto. 
 
 (Please Note: If you just want to accept crypto payments, no further configuration is needed. Any crypto payment will be received in the unique wallet address associated with your account. You can see your wallet address if you click on the top right corner of the app, section "My Wallet".)
 


### PR DESCRIPTION
## Description

I noticed a typo where "prefered" was used instead of "preferred."
I’ve fixed it to reflect the correct spelling. Let me know if you need any further changes!

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [x] Documentation

