### PR TITLE
docs: Fix grammatical error in the "Payments for AI Agents and Apps" …

### DIFF
--- a/docs/getting-started/payments-for-ai.mdx
+++ b/docs/getting-started/payments-for-ai.mdx
@@ -17,7 +17,7 @@ Payment Plans give AI Builders the ability to control how and when users can use
 service. They are entirely controlled and managed by the AI Builder that creates them with no
 interference from Nevermined.
 
-As an AI Builder, you can create a Payment Plan for your AI that give you the ability to:
+As an AI Builder, you can create a Payment Plan for your AI that gives you the ability to:
 
 - Create a time-based or request-based access token, called Credits, for your AI
 - Set a price, starting from Free, to access your AI (supporting any type of currency)


### PR DESCRIPTION
## Description

I noticed a grammatical issue in the text. The sentence "Payment Plan for your AI that give you the ability to" was corrected to "Payment Plan for your AI that **gives** you the ability to" to ensure subject-verb agreement.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

