### PR TITLE
docs: Corrected verb agreement in subscription sentence

### DIFF
--- a/docs/environments/05-production.md
+++ b/docs/environments/05-production.md
@@ -32,7 +32,7 @@ The environments flagged with **Only Protocol** don't have deployed with the Nev
 
 ## Network Fees
 
-Nevermined is free to use for builders. Anyone can publish AI services and data for free. Nevermined collects a `1%` fee when there is payment involved. So when a subscriber pay for a subscription, Nevermined collects a `1%` fee of that. If the payment is done via a credit card (with Stripe), Stripe will also collect a fee.
+Nevermined is free to use for builders. Anyone can publish AI services and data for free. Nevermined collects a `1%` fee when there is payment involved. So when a subscriber pays for a subscription, Nevermined collects a `1%` fee of that. If the payment is done via a credit card (with Stripe), Stripe will also collect a fee.
 
 :::info
 


### PR DESCRIPTION
## Description

I noticed a small issue with verb agreement in the sentence: "When a subscriber pay for a subscription." The verb should be "pays" instead of "pay" to match the singular subject "subscriber."

I've updated it to "When a subscriber pays for a subscription" for correctness.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [x] Documentation

